### PR TITLE
Update cometd.js to fix a critical typo

### DIFF
--- a/cometd.js
+++ b/cometd.js
@@ -22,7 +22,7 @@ define(['org/cometd', 'dojo/json', 'dojox', 'dojo/_base/xhr', 'dojo/io/script', 
 
     dojox.Cometd = function(name)
     {
-        var cometd = new org_cometd.Cometd(name);
+        var cometd = new org_cometd.CometD(name);
 
         function LongPollingTransport()
         {


### PR DESCRIPTION
There is a typo for calling the main function.
